### PR TITLE
Exposes argument to turn on/off morphy

### DIFF
--- a/wn/__init__.py
+++ b/wn/__init__.py
@@ -126,7 +126,7 @@ class WordNet(WordNetPaths, InformationContentSimilarities, OpenMultilingualWord
         # Return the synset object.
         return synset
 
-    def synsets(self, lemma, pos=None, lang='eng', check_exceptions=True):
+    def synsets(self, lemma, pos=None, lang='eng', check_exceptions=True, use_morphy=True):
         """
         Load all synsets with a given lemma and part of speech tag.
         If no pos is specified, all synsets for all parts of speech
@@ -139,8 +139,15 @@ class WordNet(WordNetPaths, InformationContentSimilarities, OpenMultilingualWord
         if lang == 'eng':
             list_of_synsets = []
             for p in pos_tags:
-                form = morphy(lemma, p, check_exceptions)
-                for offset in _lemma_pos_offset_map[form].get(p, []):
+                # Tries to first fetch offsets using the lemma
+                offsets = _lemma_pos_offset_map[lemma].get(p, [])
+                # If no offsets is fetched from lemma and use_morphy is True.
+                # Fetch offsets using morphy lemmatized word.
+                if not offsets and use_morphy:
+                    form = morphy(lemma, p, check_exceptions)
+                    offsets = _lemma_pos_offset_map[offset].get(p, [])
+                # Iterate through the offsets to append the Synset objects.
+                for offset in offsets:
                     if offset in _synset_offset_cache[p]:
                         list_of_synsets.append(_synset_offset_cache[p][offset])
                     else:

--- a/wn/__init__.py
+++ b/wn/__init__.py
@@ -139,15 +139,11 @@ class WordNet(WordNetPaths, InformationContentSimilarities, OpenMultilingualWord
         if lang == 'eng':
             list_of_synsets = []
             for p in pos_tags:
-                # Tries to first fetch offsets using the lemma
-                offsets = _lemma_pos_offset_map[lemma].get(p, [])
-                # If no offsets is fetched from lemma and use_morphy is True.
-                # Fetch offsets using morphy lemmatized word.
-                if not offsets and use_morphy:
-                    form = morphy(lemma, p, check_exceptions)
-                    offsets = _lemma_pos_offset_map[offset].get(p, [])
+                # If users wants to enforce only lemma checks, then
+                # `use_morphy=False` should be set.
+                form = morphy(lemma, p, check_exceptions) if use_morphy else lemma
                 # Iterate through the offsets to append the Synset objects.
-                for offset in offsets:
+                for offset in _lemma_pos_offset_map[form].get(p, []):
                     if offset in _synset_offset_cache[p]:
                         list_of_synsets.append(_synset_offset_cache[p][offset])
                     else:


### PR DESCRIPTION
I would propose to keep the default behavior because having more relaxed rules to fetch more usually helps for downstream applications. 

And exposing an argument that will turn the morphy lemmatization off when user wants strict matching: 

```python
    def synsets(self, lemma, pos=None, lang='eng', check_exceptions=True, use_morphy=True):
        """
        Load all synsets with a given lemma and part of speech tag.
        If no pos is specified, all synsets for all parts of speech
        will be loaded.
        If lang is specified, all the synsets associated with the lemma name
        of that language will be returned.
        """
        lemma = lemma.lower()
        pos_tags = POS_LIST if pos == None else [pos]
        if lang == 'eng':
            list_of_synsets = []
            for p in pos_tags:
                # If users wants to enforce only lemma checks, then
                # `use_morphy=False` should be set.
                form = morphy(lemma, p, check_exceptions) if use_morphy else lemma
                # Iterate through the offsets to append the Synset objects.
                for offset in _lemma_pos_offset_map[form].get(p, []):
                     ...
```

**Usage:**

```python
>>> from wn import WordNet
>>> wn = WordNet()
>>> wn.synsets('eyeglasses')
[Synset('spectacles.n.01')]
>>> wn.synsets('geese')
[Synset('goose.n.01'), Synset('fathead.n.01'), Synset('goose.n.03')]
>>> wn.synsets('geese', use_morphy=False)
[]
```