### PR TITLE
Remove misleading pip install from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,6 @@
 [![Build Status](https://travis-ci.org/nltk/wordnet.svg?branch=master)](https://travis-ci.org/nltk/wordnet)
 
 
-# Install
-
-```
-pip install -U wn
-```
-
-
 # Use
 
 ```python


### PR DESCRIPTION
https://pypi.org/project/wn/ is a different project, so the installation instructions currently do not work.

See also: https://github.com/goodmami/wn/issues/35